### PR TITLE
Add pob.studio as a viewing tool for Labitbu

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ Have a great tool? Open an issue or a PR!
 
 ## Labitbu Viewing Tools
 - https://labitbu-extractor.lovable.app - Labitbu Extractor: paste in a transaction to render your labitbu
+- https://pob.studio - Labitbu Extractor and visualizer: paste any transaction and renders labitbu.
 - https://ordinals.com/content/e2102e01694cf856346e73b409f6aace291e486a0cacc513dfa831346007e6cfi0 - onchain labitbu parser. pass the txid as a param, or make it a delegate for a labitbuscription. for example: https://ordinals.com/content/e2102e01694cf856346e73b409f6aace291e486a0cacc513dfa831346007e6cfi0?txid=29e6a20c72cdcb5398eb2e92800824b95e9162277a2f0ff53a70c7a186ec4a3f
 


### PR DESCRIPTION
Per title, added the pob.studio dapp which renders the `webp` embedded in the control block of any labitbu tx.