### PR TITLE
Update: Add Taproot address support to extraction instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Have a great tool? Open an issue or a PR!
 
 ## Individual Labitbu Viewing/Decoding Tools
 - https://labitbu-extractor.lovable.app - Labitbu Extractor: paste in a transaction to render your labitbu
-- https://pob.studio - Labitbu Extractor and visualizer: paste any transaction and renders labitbu (paste txid into the search box to render an image, click the image and then select "Show Details").
+- https://pob.studio - Labitbu Extractor & Visualizer: Paste any minting transaction or Taproot address to render its Labitbu. (Paste the txid or address into the search tool, click the image, then select "Show Details.")
 - https://ordinals.com/content/e2102e01694cf856346e73b409f6aace291e486a0cacc513dfa831346007e6cfi0 - onchain labitbu parser. pass the txid as a param, or make it a delegate for a labitbuscription. for example: https://ordinals.com/content/e2102e01694cf856346e73b409f6aace291e486a0cacc513dfa831346007e6cfi0?txid=29e6a20c72cdcb5398eb2e92800824b95e9162277a2f0ff53a70c7a186ec4a3f
 - https://webp.orange.surf
 


### PR DESCRIPTION
Clarifies that users can paste either a minting transaction or a Taproot address used in the mint to render Labitbu images.